### PR TITLE
Use the notebook format version (not nbformat package version) fixes #8

### DIFF
--- a/nbimporter.py
+++ b/nbimporter.py
@@ -69,7 +69,7 @@ class NotebookLoader(object):
         path = find_notebook(fullname, self.path)
 
         # load the notebook object
-        nb_version = nbformat.version_info[0]
+        nb_version = nbformat.current_nbformat
         
         with io.open(path, 'r', encoding=options['encoding']) as f:
             nb = nbformat.read(f, nb_version)


### PR DESCRIPTION
See https://github.com/jupyter/nbformat/issues/164#issuecomment-614813599 for confirmation that this is the way to get the current version.