### PR TITLE
Relaxing the way we test a notebook is a python notebook

### DIFF
--- a/nbimporter.py
+++ b/nbimporter.py
@@ -83,7 +83,7 @@ class NotebookLoader(object):
         mod.__dict__['get_ipython'] = get_ipython
 
         # Only do something if it's a python notebook
-        if ('python' not in nb.metadata.kernelspec.language):
+        if 'python' not in nb.metadata.kernelspec.language:
             print("Ignoring '%s': not a python notebook." % path)
             return mod
 

--- a/nbimporter.py
+++ b/nbimporter.py
@@ -83,7 +83,7 @@ class NotebookLoader(object):
         mod.__dict__['get_ipython'] = get_ipython
 
         # Only do something if it's a python notebook
-        if nb.metadata.kernelspec.language != 'python':
+        if ('python' not in nb.metadata.kernelspec.language):
             print("Ignoring '%s': not a python notebook." % path)
             return mod
 


### PR DESCRIPTION
now just check if 'python' is in the kernelspec.language string, this will then work for python and python3 language specs.

fixes #10