### PR TITLE
Remove stray print statement

### DIFF
--- a/nbimporter.py
+++ b/nbimporter.py
@@ -87,7 +87,7 @@ class NotebookLoader(object):
             print("Ignoring '%s': not a python notebook." % path)
             return mod
 
-        print("Importing Jupyter notebook from %s" % path)
+        # print("Importing Jupyter notebook from %s" % path)
         sys.modules[fullname] = mod
 
         # extra work to ensure that magics that would affect the user_ns


### PR DESCRIPTION
Removing print statement that gets output all the time, including with automated `jupyter` runs via `papermill`